### PR TITLE
Fix bug in getHash method

### DIFF
--- a/android/src/main/java/com/faizal/OtpVerify/RNOtpVerifyModule.java
+++ b/android/src/main/java/com/faizal/OtpVerify/RNOtpVerifyModule.java
@@ -51,9 +51,10 @@ public class RNOtpVerifyModule extends ReactContextBaseJavaModule implements Lif
             AppSignatureHelper helper = new AppSignatureHelper(reactContext);
             ArrayList<String> signatures = helper.getAppSignatures();
             WritableArray arr = Arguments.createArray();
-            for (String s : signatures)
+            for (String s : signatures) {
                 arr.pushString(s);
-            promise.resolve(signatures);
+            }
+            promise.resolve(arr);
         } catch (Exception e) {
             promise.reject(e);
         }


### PR DESCRIPTION
Get hash method was trying to return an ArrayList, this resulted in an error because the promise could not be resolved with this type.