### PR TITLE
Improved Gradle setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,29 +1,31 @@
 buildscript {
-    repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
         }
-    }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        dependencies {
+            classpath("com.android.tools.build:gradle:3.6.1")
+        }
     }
 }
 
 apply plugin: 'com.android.library'
-def DEFAULT_COMPILE_SDK_VERSION = 26
-def DEFAULT_BUILD_TOOLS_VERSION = "28.0.2"
-def DEFAULT_TARGET_SDK_VERSION = 26
-def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION = "+"
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }
@@ -35,15 +37,11 @@ android {
 repositories {
     mavenCentral()
     google()
-    maven {
-        url 'https://maven.google.com/'
-        name 'Google'
-    }
 }
 
 dependencies {
-    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion
-            : project.hasProperty('playServiceVersion') ? project.playServiceVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+    def googlePlayServicesVersion = safeExtGet('googlePlayServicesVersion', safeExtGet('playServiceVersion', '+')) 
+
     implementation 'com.facebook.react:react-native:+'
     implementation "com.google.android.gms:play-services-auth:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
- Load Android Gradle Plugin conditionally

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)

- removed unnecessary buildToolsVersion specification

in newer versions of Android Gradle Plugin, it's no longer needed to specify `buildToolsVersion` the plugin itself will peek the correct version automatically.

- extracted duplicated default versions extraction from the root project Gradle setup into a function

it's a common between RN libraries to use auxiliary function `safeExtGet` to get rid the duplicated codes for extracting versions from the root project'S Gradle setup 