### PR TITLE
Fix null object crash.

### DIFF
--- a/android/src/main/java/com/faizal/OtpVerify/OtpBroadcastReceiver.java
+++ b/android/src/main/java/com/faizal/OtpVerify/OtpBroadcastReceiver.java
@@ -48,6 +48,10 @@ public class OtpBroadcastReceiver extends BroadcastReceiver {
             Bundle extras = intent.getExtras();
             Status status = (Status) extras.get(SmsRetriever.EXTRA_STATUS);
 
+            if (status == null) {
+                return;
+            }
+
             switch (status.getStatusCode()) {
                 case CommonStatusCodes.SUCCESS:
                     // Get SMS message contents


### PR DESCRIPTION
No matter what reason, I encounter one case in which status is null, so this PR fix the crash caused by that.

> NullPointerException: Attempt to invoke virtual method 'int com.google.android.gms.common.api.Status.getStatusCode()' on a null object reference
    at com.faizal.OtpVerify.OtpBroadcastReceiver.onReceive(OtpBroadcastReceiver.java:51)


> device = Nexus 4 device.family = Nexus environment = prod event.environment = java event.origin = android hermes = true language = en level = fatal os = Android 6.0.1