### PR TITLE
Null pointer check applied

### DIFF
--- a/android/src/main/java/com/faizal/OtpVerify/OtpBroadcastReceiver.java
+++ b/android/src/main/java/com/faizal/OtpVerify/OtpBroadcastReceiver.java
@@ -57,7 +57,9 @@ public class OtpBroadcastReceiver extends BroadcastReceiver {
                     // Get SMS message contents
                     String message = (String) extras.get(SmsRetriever.EXTRA_SMS_MESSAGE);
                     receiveMessage(message);
-                    Log.d("SMS", message);
+                    if (message != null) {
+                        Log.d("SMS", message);
+                    }
                     break;
                 case CommonStatusCodes.TIMEOUT:
                     Log.d("SMS", "Timeout error");


### PR DESCRIPTION
Log.d internally uses the print method which needs not null value