### PR TITLE
Fix: IOS 'RNOtpVerify.getOtp'

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,8 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var react_native_1 = require("react-native");
 var RNOtpVerify = react_native_1.NativeModules.RNOtpVerify;
 var OtpVerify = {
-    getOtp: RNOtpVerify.getOtp,
-    getHash: RNOtpVerify.getHash,
+    getOtp: RNOtpVerify === null || RNOtpVerify === void 0 ? void 0 : RNOtpVerify.getOtp,
+    getHash: RNOtpVerify === null || RNOtpVerify === void 0 ? void 0 : RNOtpVerify.getHash,
     addListener: function (handler) {
         return react_native_1.DeviceEventEmitter
             .addListener('com.faizalshap.otpVerify:otpReceived', handler);

--- a/index.ts
+++ b/index.ts
@@ -10,8 +10,8 @@ interface OtpVerify {
 }
 
 const OtpVerify: OtpVerify = {
-    getOtp: RNOtpVerify.getOtp,
-    getHash: RNOtpVerify.getHash,
+    getOtp: RNOtpVerify?.getOtp,
+    getHash: RNOtpVerify?.getHash,
 
     addListener: (handler) =>
         DeviceEventEmitter

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "react-native-otp-verify",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
+      "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.63.52",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.52.tgz",
+      "integrity": "sha512-sBXvvtJaIUSXQLDh9NZitx1KHkKUdBLZy34lFKJaIXtpHIh5OEbBXeyUTFBtFwjk/RD0tneAtUqsdhheZRzAzw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+      "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "url": "git@github.com:faizalshap/react-native-otp-verify.git"
   },
   "peerDependencies": {
-    "react-native": "^0.57.3"
+    "react-native": "^0.63.2"
   },
   "devDependencies": {
-    "@types/react-native": "^0.57.6",
+    "@types/react-native": "^0.63.2",
     "typescript": "^3.1.3"
   }
 }


### PR DESCRIPTION
Hello @faizalshap,

IOS "TypeError: null is not an object (evaluatin 'RNOtpVerify.getOtp')" error fix. With this pull request issue #23 is fixed.
