### PR TITLE
Fix crash due to null extras in OtpBroadcastReceiver.java

### DIFF
--- a/android/src/main/java/com/faizal/OtpVerify/OtpBroadcastReceiver.java
+++ b/android/src/main/java/com/faizal/OtpVerify/OtpBroadcastReceiver.java
@@ -46,6 +46,9 @@ public class OtpBroadcastReceiver extends BroadcastReceiver {
         String o = intent.getAction();
         if (SmsRetriever.SMS_RETRIEVED_ACTION.equals(o)) {
             Bundle extras = intent.getExtras();
+            if (extras == null) {
+                return;
+            }
             Status status = (Status) extras.get(SmsRetriever.EXTRA_STATUS);
 
             if (status == null) {


### PR DESCRIPTION
<img width="1079" alt="image" src="https://github.com/faizalshap/react-native-otp-verify/assets/98765189/e382646f-5c8a-4b73-aa7d-de5e16356169">
This crash was reported on Sentry, please consider it merging as a quick fix.