### PR TITLE
fix:  android build fail due to CREDENTIALS_API

### DIFF
--- a/android/src/main/java/com/faizal/OtpVerify/OtpVerifyModule.java
+++ b/android/src/main/java/com/faizal/OtpVerify/OtpVerifyModule.java
@@ -51,7 +51,7 @@ public class OtpVerifyModule extends ReactContextBaseJavaModule implements Lifec
         registerReceiverIfNecessary(mReceiver);
         reactContext.addActivityEventListener(this);
         apiClient = new GoogleApiClient.Builder(reactContext)
-                .addApi(Auth.CREDENTIALS_API)
+                .addApi(Auth.GOOGLE_SIGN_IN_API)
                 .build();
     }
 


### PR DESCRIPTION
Fixes build error
Build was failed, and i got following error:

`Note: Recompile with -Xlint:deprecation for details.
/Users/steavenbc/Documents/codes/ws-mobile/ws-mobile/node_modules/react-native-otp-verify/android/src/main/java/com/faizal/OtpVerify/OtpVerifyModule.java:54: error: cannot find symbol
.addApi(Auth.CREDENTIALS_API)
^
symbol: variable CREDENTIALS_API
location: class Auth
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 error

FAILURE: Build failed with an exception.

What went wrong:
Execution failed for task ':react-native-otp-verify:compileReleaseJavaWithJavac'.



fixes:  #108