### PR TITLE
android - add support for AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,10 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+        namespace 'com.faizal.OtpVerify'
+    }
     compileSdkVersion safeExtGet('OtpVerify_compileSdkVersion', 34)
     defaultConfig {
         minSdkVersion safeExtGet('OtpVerify_minSdkVersion', 21)


### PR DESCRIPTION
> Change to support AGP 8 as mentioned here: [react-native-community/discussions-and-proposals#671](https://github.com/react-native-community/discussions-and-proposals/issues/671)
> 
> This does not remove package attribute from AndroidManifest to not lose compatibility with AGP < 8 (React Native < 0.71 versions).
> 
> I don't think it's worth maintaining logic to remove that attribute contitionally since it will [only cause a warning to users on AGP 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1607191009) and above.

MR adapted from @AndreiCalazans work found in [another project](https://github.com/LinusU/react-native-get-random-values/pull/48)