### PR TITLE
Update OtpVerify.h to prevent `new NativeEventEmitter()` warnings

### DIFF
--- a/ios/OtpVerify.h
+++ b/ios/OtpVerify.h
@@ -1,5 +1,6 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface OtpVerify : NSObject <RCTBridgeModule>
+@interface OtpVerify : RCTEventEmitter <RCTBridgeModule>
 
 @end


### PR DESCRIPTION
This addresses #74 in ios.

Before:
We see in logs(if LogBox warnings are disabled):
```
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
 WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
```

After:
logs are clean.